### PR TITLE
Upgrade mkdocs-material to v1.5.4

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -29,7 +29,7 @@ This work would not have been possible without the help of the MadWeight team an
 <div style="display: flex; flex-wrap: wrap; justify-content: space-around; height: 120px">
     <a href="https://uclouvain.be/fr/index.html" style="height: 100%"><img alt="UCL logo" src="/images/UCL_mention_RVB_web.jpg" style="display: block; width: auto; max-height: 100%;" /></a>
     <a href="http://cp3.irmp.ucl.ac.be/" style="height: 100%"><img alt="CP3 logo" src="/images/CP3_logo.png" style="display: block; width: auto; max-height: 100%;" /></a>
-    <a href="http://www.frs-fnrs.be/" style="height: 100%"><img alt="CP3 logo" src="/images/FRS-FNRS_negatif_UK_CS.png" style="display: block; width: auto; max-height: 100%;" /></a>
+    <a href="http://www.frs-fnrs.be/" style="height: 100%"><img alt="FNRS logo" src="/images/FRS-FNRS_negatif_UK_CS.png" style="display: block; width: auto; max-height: 100%;" /></a>
     <a href="https://amva4newphysics.wordpress.com/" style="height: 100%"><img alt="AMVA4NewPhysics logo" src="/images/small_amva4.png" style="display: block; width: auto; max-height: 100%;" /></a>
     <a href="https://europa.eu/" style="height: 100%"><img alt="European Union logo" src="/images/ue_flag.jpg" style="display: block; width: auto; max-height: 100%;" /></a>
 </div>

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 mkdocs==0.16.2
-mkdocs-material==1.5.0
+mkdocs-material==1.5.4
 Pygments==2.2.0
 pymdown-extensions==2.0
 python-markdown-math==0.3


### PR DESCRIPTION
No real impacting bugs, but still a handful ones fixed, see the official changelog here: https://github.com/squidfunk/mkdocs-material/blob/master/CHANGELOG

I also fixed the `alt` tag of one of the logo which was not correct. I was already the case in #9 so the blame is on me :smile:.

Note: a simple `(sudo) pip install -r requirements.txt` is enough to upgrade the theme once this is merged.