### PR TITLE
Update dependencies

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -45,7 +45,7 @@ markdown_extensions:
 
 # MathJax
 extra_javascript:
-  - https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS_CHTML
+  - https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS-MML_HTMLorMML
 
 extra_css:
   - 'stylesheets/base16-eighties.dark.css'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-mkdocs==0.16.2
+mkdocs==0.16.3
 mkdocs-material==1.6.1
 Pygments==2.2.0
 pymdown-extensions==2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 mkdocs==0.16.2
-mkdocs-material==1.5.4
+mkdocs-material==1.6.1
 Pygments==2.2.0
 pymdown-extensions==2.0
 python-markdown-math==0.3


### PR DESCRIPTION
Updates mkdocs and mkdocs-material to their latest version. Futhermore, the CDN we use for MathJax is now deprecated, so I switched to the new recommended one. I also changed the default options used for MathJax, resulting in a nicer LaTeX output.

To update:
```
[sudo] pip install -r requirements.txt
```